### PR TITLE
Updated MessageThread GET to accept get variables

### DIFF
--- a/app/chatview.py
+++ b/app/chatview.py
@@ -21,27 +21,27 @@ def renderreferencepage():
 def getmessagethread():
 	messages = []
 	#set time param
-	if request.json.get('time_sent'):
-		if request.json.get('time_sent') == 'today':
+	if request.args.get('time_sent'):
+		if request.args.get('time_sent') == 'today':
 			time_sent = 'today'
-		elif request.json.get('time_sent') == 'week':
+		elif request.args.get('time_sent') == 'week':
 			time_sent = 'week'
-		elif request.json.get('time_sent') == 'month':
+		elif request.args.get('time_sent') == 'month':
 			time_sent = 'month'
 		else:
 			abort(400)
 	else: 
 		time_sent = None
 	#set user2
-	if request.json.get('user2'):
-		user2 = request.json.get('user2')
+	if request.args.get('user2'):
+		user2 = request.args.get('user2')
 	else:
 		user2 = None
 		
-	if request.json.get('user1'):
-		user1 = request.json.get('user1')
-		if request.json.get('list_threads'):
-			if request.json.get('list_threads') == 'true':
+	if request.args.get('user1'):
+		user1 = request.args.get('user1')
+		if request.args.get('list_threads'):
+			if request.args.get('list_threads') == 'true':
 				results = chatmodel.getthreadsbyuser(user1 = user1, user2 = user2, time_sent = time_sent)
 				previously_listed_threads = []
 				for result in results:

--- a/app/templates/reference.html
+++ b/app/templates/reference.html
@@ -65,16 +65,16 @@
 					<tr><td>user1</td><td>Yes</td><td>username</td><td>Returns a list of all messages sent to and from that user.  Messages will be sorted into threads (messages between two users) and then sorted by time sent.</td></tr>
 					<tr><td>user2</td><td>No</td><td>username</td><td>Returns the thread of messages between user1 and user2 sorted by time sent.</td></tr>
 					<tr><td>list_threads</td><td>No</td><td>'true'</td><td>Returns a list of threads involving user1. (If 'user2' is set, only the thread between the two users will be returned (assuming messages exist between user1 and user2).</td></tr>
-					<tr><td>time_sent</td><td>No</td><td>'today', 'week', 'month'</td><td>Returns messages sent today, in the last week, or in the last 30 days involving user1 and user2 if set.</td></tr>
+					<tr><td>time_sent</td><td>No</td><td>'today', 'week', 'month'</td><td>Returns message threads, or a list of threads with messages sent today, in the last week, or in the last 30 days involving user1 and user2 if set.</td></tr>
 					</tbody>
 					</table>
 
 					<h4>Examples</h4>
 					<hr>
 					<h6>cURL Command Line Template</h6>
-					<p class="tab" id="codebox">curl -H 'Content-Type: application/json' -X GET -d '{"user1":"[username]","user2":"[username],"list_threads":"true", "time_sent":"[today, week, month]"}' {{url}}/api/MessageThread</p>
+					<p class="tab" id="codebox">curl "{{url}}/api/MessageThread?user1=[username1]&user2=[username2]&list_threads=true&time_sent=[today, week, month]"</p>
 					<h6>Input</h6>
-					<p class="tab" id="codebox">curl -H 'Content-Type: application/json' -X GET -d '{"user1":"ecroby"}' {{url}}/api/MessageThread</p>
+					<p class="tab" id="codebox">curl "{{url}}/api/MessageThread?user1=ecroby"</p>
 					<h6>Output</h6>
 					<p class="tab" id="codebox">
 					[<br>
@@ -105,7 +105,7 @@
 					]
 					</p>
 					<h6>Input</h6>
-					<p class="tab" id="codebox">curl -H 'Content-Type: application/json' -X GET -d '{"user1":"ecroby","user2":"user2"}' {{url}}/api/MessageThread</p>
+					<p class="tab" id="codebox">curl "{{url}}/api/MessageThread?user1=ecroby&user2=user2"</p>
 					<h6>Output</h6>
 					<p class="tab" id="codebox">
 					[<br>


### PR DESCRIPTION
## What
Updated MessageThread GET to accept get variables. reflected in reference page.

## Why
Seems to be more commonplace to use get variables than JSON for sending GET method parameters.

## Test
* Change to this branch
* Go to reference page and look at the MessageThread GET section: http://localhost:5000/#MessageThread-GET
* Test sending a few requests.  Make sure to use all of the parameters to make sure they still work.  Try different combinations of parameters.
* Merge if works